### PR TITLE
fix JSON.parse error (shared NSUserDefaults)

### DIFF
--- a/UserDefaults.js
+++ b/UserDefaults.js
@@ -9,7 +9,7 @@ const {
 
 const userDefaults = {
   set: (key, value, suiteName, cb) => {
-    const jsonValue = JSON.stringify(value)
+    const jsonValue = typeof data === 'string' || typeof data === 'number' ? data : JSON.stringify(value)
     return new Promise((resolve, reject) => {
       UserDefaults.setObject(key, jsonValue, suiteName, (err, data) => {
         if (err) {
@@ -32,7 +32,7 @@ const userDefaults = {
           cb && cb(error)
           reject(error)
         } else {
-          const result = JSON.parse(data)
+          const result = typeof data === 'string' || typeof data === 'number' ? data : JSON.parse(data)
           cb && cb(null, result)
           resolve(result)
         }

--- a/UserDefaults.js
+++ b/UserDefaults.js
@@ -9,7 +9,7 @@ const {
 
 const userDefaults = {
   set: (key, value, suiteName, cb) => {
-    const jsonValue = typeof data === 'string' || typeof data === 'number' ? data : JSON.stringify(value)
+    const jsonValue = typeof value === 'string' || typeof value === 'number' ? value : JSON.stringify(value)
     return new Promise((resolve, reject) => {
       UserDefaults.setObject(key, jsonValue, suiteName, (err, data) => {
         if (err) {


### PR DESCRIPTION
**When `NSUserDefaults` is shared (_via group_) with a widget for instance it can lead to JSON.parse error when value stored by widget is a JS primitive: string or number.**

Fix here `userDefaults.get` and `userDefaults.set` for 
- string
- number

``` objective-c
// in swift, your widget could store :
let userDefaults = NSUserDefaults(suiteName: "SUITE_NAME")
userDefaults?.setObject("a string for this key", forKey:"KEY_NAME")
userDefaults?.synchronize()
```

> this fix insure `string` and `number` won't throw errors.
