### PR TITLE
add .podspec file for cocoapods support

### DIFF
--- a/RCTUserDefaults.podspec
+++ b/RCTUserDefaults.podspec
@@ -1,0 +1,18 @@
+require 'json'
+version = JSON.parse(File.read('package.json'))["version"]
+
+Pod::Spec.new do |s|
+
+  s.name           = "RCTUserDefaults"
+  s.version        = version
+  s.summary        = "React Native User Defaults"
+  s.homepage       = "https://github.com/wwayne/react-native-user-defaults"
+  s.license        = "MIT"
+  s.author         = "wwayne"
+  s.platform       = :ios, "7.0"
+  s.source         = { :git => "https://github.com/wwayne/react-native-user-defaults", :tag => "v#{s.version}" }
+  s.source_files   = '*.{h,m}'
+  s.preserve_paths = "**/*.js"
+  s.dependency 'React'
+
+end


### PR DESCRIPTION
Hi I used your plugin for a few months and I liked it very much ! But every time I have to manually add .podspec to get it work with cocoapods. >__< Hope this pull request can be merged so it get cocoapods support and installation can be automated :p Thanks !!